### PR TITLE
build: bump Go to 1.26.0

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,5 +1,5 @@
 FROM bufbuild/buf:1 AS buf
-FROM golang:1.24-alpine AS go
+FROM golang:1.26-alpine AS go
 
 RUN go install -mod=readonly google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.6
 RUN go install -mod=readonly connectrpc.com/connect/cmd/protoc-gen-connect-go@v1.18.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/qpoint-io/proto
 
-go 1.24.1
+go 1.26.0
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.6-20250307204501-0409229c3780.1


### PR DESCRIPTION
Updates Go version to 1.26.0 across go.mod, CI workflows, and Dockerfiles.