### PR TITLE
bump go to 1.26.2

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,5 +1,5 @@
 FROM bufbuild/buf:1 AS buf
-FROM golang:1.26-alpine AS go
+FROM golang:1.26.2-alpine AS go
 
 RUN go install -mod=readonly google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.6
 RUN go install -mod=readonly connectrpc.com/connect/cmd/protoc-gen-connect-go@v1.18.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/qpoint-io/proto
 
-go 1.26.0
+go 1.26.2
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.6-20250307204501-0409229c3780.1


### PR DESCRIPTION
Updates this repo to Go 1.26.2 only.